### PR TITLE
backend: fix typo in readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# NEAR Explorer Frontend
+# NEAR Explorer Backend
 
 ## Project Structure
 


### PR DESCRIPTION
The backend README says in its title that it is the frontend README.
Surely that was a typo.